### PR TITLE
 docs: update logo to Ansys instead of PyAnsys

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -45,7 +45,7 @@ html_theme_options = {
         "version_match": get_version_match(version),
     },
     "check_switcher": False,
-    "logo": "pyansys",
+    "logo": "ansys",
 }
 
 # Sphinx extensions

--- a/doc/source/contributing.rst
+++ b/doc/source/contributing.rst
@@ -52,7 +52,7 @@ source and enhance it.
    .. code:: bash
 
       python -m pip install -U pip     # Upgrading pip
-      python -m pip install -r requierements/doc.txt     # for building the documentation
+      python -m pip install -r requirements/requirements_doc.txt     # for building the documentation
 
 Use ``pre-commit``
 ^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Small PR to unify doc logos: all `scade-example*` and `scadeone-example*` repos should have an Ansys logo in their docs, not a PyAnsys one.
